### PR TITLE
loglevel -> loglevel-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ loglevelDebug.enable('worker:*');
 
 ```js
 var loglevel = require('loglevel');
-var loglevelDebug = require('loglevel');
+var loglevelDebug = require('loglevel-debug');
 
 loglevelDebug(loglevel);
 


### PR DESCRIPTION
Fixed typo in:

```js
var loglevel = require('loglevel');
var loglevelDebug = require('loglevel');
```