### PR TITLE
Allow Logger objects to have their levels set

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function loglevelDebug(nameOrLogger) {
     log = _loggers[nameOrLogger] = require('loglevel').getLogger(nameOrLogger);
   }
   else if (typeof nameOrLogger === 'object') {
-    log = nameOrLogger;
+    log = _loggers[nameOrLogger.name] = nameOrLogger;
   }
   else {
     log = require('loglevel');


### PR DESCRIPTION
## Current broken behavior

When `loglevelDebug()` is passed an Object (rather than a String) and `DEBUG` is truthy, the logger won't have its level set in `enable()` because it won't appear in the `_loggers` object.

## New behavior

If `loglevelDebug()` is passed an Object, it will now get added to the `_loggers` object.